### PR TITLE
NTU-V2 configs and minor fixes

### DIFF
--- a/configs/NTU-V2/final/IRN_final_no_rel_att_after.cfg
+++ b/configs/NTU-V2/final/IRN_final_no_rel_att_after.cfg
@@ -1,0 +1,13 @@
+[fusion]
+config_filepaths = ['configs/NTU-V2/final/final_joint_no_rel_att.cfg', 'configs/NTU-V2/final/final_temp_no_rel_att.cfg']
+weights_filepaths = ['models/NTU-V2/final_joint_no_rel_att/fold_cross_x/rerun_x/relnet_weights.hdf5', 'models/NTU-V2/final_temp_no_rel_att/fold_cross_x/rerun_x/relnet_weights.hdf5']
+freeze_g_theta = False
+fuse_at_fc1 = False
+new_arch = True
+avg_at_end = True
+
+[train]
+drop_rate = 0.1
+epochs = 200
+learning_rate = 0.0001
+checkpoint_period = 1

--- a/configs/NTU-V2/final/IRN_final_no_rel_att_before.cfg
+++ b/configs/NTU-V2/final/IRN_final_no_rel_att_before.cfg
@@ -1,0 +1,13 @@
+[fusion]
+config_filepaths = ['configs/NTU-V2/final/final_joint_no_rel_att.cfg', 'configs/NTU-V2/final/final_temp_no_rel_att.cfg']
+weights_filepaths = ['models/NTU-V2/final_joint_no_rel_att/fold_cross_x/rerun_x/relnet_weights.hdf5', 'models/NTU-V2/final_temp_no_rel_att/fold_cross_x/rerun_x/relnet_weights.hdf5']
+freeze_g_theta = False
+fuse_at_fc1 = False
+new_arch = True
+avg_at_end = False
+
+[train]
+drop_rate = 0.1
+epochs = 200
+learning_rate = 0.0001
+checkpoint_period = 1

--- a/configs/NTU-V2/final/IRN_final_no_rel_ave_after.cfg
+++ b/configs/NTU-V2/final/IRN_final_no_rel_ave_after.cfg
@@ -1,0 +1,13 @@
+[fusion]
+config_filepaths = ['configs/NTU-V2/final/final_joint_no_rel_ave.cfg', 'configs/NTU-V2/final/final_temp_no_rel_ave.cfg']
+weights_filepaths = ['models/NTU-V2/final_joint_no_rel_ave/fold_cross_x/rerun_x/relnet_weights.hdf5', 'models/NTU-V2/final_temp_no_rel_ave/fold_cross_x/rerun_x/relnet_weights.hdf5']
+freeze_g_theta = False
+fuse_at_fc1 = False
+new_arch = True
+avg_at_end = True
+
+[train]
+drop_rate = 0.1
+epochs = 200
+learning_rate = 0.0001
+checkpoint_period = 1

--- a/configs/NTU-V2/final/IRN_final_no_rel_ave_before.cfg
+++ b/configs/NTU-V2/final/IRN_final_no_rel_ave_before.cfg
@@ -1,0 +1,13 @@
+[fusion]
+config_filepaths = ['configs/NTU-V2/final/final_joint_no_rel_ave.cfg', 'configs/NTU-V2/final/final_temp_no_rel_ave.cfg']
+weights_filepaths = ['models/NTU-V2/final_joint_no_rel_ave/fold_cross_x/rerun_x/relnet_weights.hdf5', 'models/NTU-V2/final_temp_no_rel_ave/fold_cross_x/rerun_x/relnet_weights.hdf5']
+freeze_g_theta = False
+fuse_at_fc1 = False
+new_arch = True
+avg_at_end = False
+
+[train]
+drop_rate = 0.1
+epochs = 200
+learning_rate = 0.0001
+checkpoint_period = 1

--- a/configs/NTU-V2/final/IRN_final_rel_att_after.cfg
+++ b/configs/NTU-V2/final/IRN_final_rel_att_after.cfg
@@ -1,0 +1,13 @@
+[fusion]
+config_filepaths = ['configs/NTU-V2/final/final_joint_rel_att.cfg', 'configs/NTU-V2/final/final_temp_rel_att.cfg']
+weights_filepaths = ['models/NTU-V2/final_joint_rel_att/fold_cross_x/rerun_x/relnet_weights.hdf5', 'models/NTU-V2/final_temp_rel_att/fold_cross_x/rerun_x/relnet_weights.hdf5']
+freeze_g_theta = False
+fuse_at_fc1 = False
+new_arch = True
+avg_at_end = True
+
+[train]
+drop_rate = 0.1
+epochs = 200
+learning_rate = 0.0001
+checkpoint_period = 1

--- a/configs/NTU-V2/final/IRN_final_rel_att_before.cfg
+++ b/configs/NTU-V2/final/IRN_final_rel_att_before.cfg
@@ -1,0 +1,13 @@
+[fusion]
+config_filepaths = ['configs/NTU-V2/final/final_joint_rel_att.cfg', 'configs/NTU-V2/final/final_temp_rel_att.cfg']
+weights_filepaths = ['models/NTU-V2/final_joint_rel_att/fold_cross_x/rerun_x/relnet_weights.hdf5', 'models/NTU-V2/final_temp_rel_att/fold_cross_x/rerun_x/relnet_weights.hdf5']
+freeze_g_theta = False
+fuse_at_fc1 = False
+new_arch = True
+avg_at_end = False
+
+[train]
+drop_rate = 0.1
+epochs = 200
+learning_rate = 0.0001
+checkpoint_period = 1

--- a/configs/NTU-V2/final/IRN_final_rel_ave_after.cfg
+++ b/configs/NTU-V2/final/IRN_final_rel_ave_after.cfg
@@ -1,0 +1,13 @@
+[fusion]
+config_filepaths = ['configs/NTU-V2/final/final_joint_rel_ave.cfg', 'configs/NTU-V2/final/final_temp_rel_ave.cfg']
+weights_filepaths = ['models/NTU-V2/final_joint_rel_ave/fold_cross_x/rerun_x/relnet_weights.hdf5', 'models/NTU-V2/final_temp_rel_ave/fold_cross_x/rerun_x/relnet_weights.hdf5']
+freeze_g_theta = False
+fuse_at_fc1 = False
+new_arch = True
+avg_at_end = True
+
+[train]
+drop_rate = 0.1
+epochs = 200
+learning_rate = 0.0001
+checkpoint_period = 1

--- a/configs/NTU-V2/final/IRN_final_rel_ave_before.cfg
+++ b/configs/NTU-V2/final/IRN_final_rel_ave_before.cfg
@@ -1,0 +1,13 @@
+[fusion]
+config_filepaths = ['configs/NTU-V2/final/final_joint_rel_ave.cfg', 'configs/NTU-V2/final/final_temp_rel_ave.cfg']
+weights_filepaths = ['models/NTU-V2/final_joint_rel_ave/fold_cross_x/rerun_x/relnet_weights.hdf5', 'models/NTU-V2/final_temp_rel_ave/fold_cross_x/rerun_x/relnet_weights.hdf5']
+freeze_g_theta = False
+fuse_at_fc1 = False
+new_arch = True
+avg_at_end = False
+
+[train]
+drop_rate = 0.1
+epochs = 200
+learning_rate = 0.0001
+checkpoint_period = 1

--- a/configs/NTU-V2/final/final_joint_no_rel_att.cfg
+++ b/configs/NTU-V2/final/final_joint_no_rel_att.cfg
@@ -5,7 +5,7 @@ add_body_part = False
 timesteps = 32
 skip_timesteps = None
 normalization = 'NTU'
-sample_method = 'all'
+sample_method = 'central'
 arch = 'joint'
 
 [model]

--- a/configs/NTU-V2/final/final_joint_no_rel_ave.cfg
+++ b/configs/NTU-V2/final/final_joint_no_rel_ave.cfg
@@ -1,0 +1,26 @@
+[data]
+selected_joints = ['Nose', 'Neck', 'MidHip', 'RWrist', 'LWrist', 'RAnkle', 'LAnkle']
+add_joint_idx = False
+add_body_part = False
+timesteps = 32
+skip_timesteps = None
+normalization = 'NTU'
+sample_method = 'all'
+arch = 'joint'
+
+[model]
+rel_type = 'joint_stream'
+fuse_type = None
+compute_distance = False
+compute_motion = False
+use_relations = False
+use_attention = False
+return_attention = False
+
+[train]
+drop_rate = 0.1
+kernel_init_type = 'TruncatedNormal'
+learning_rate = 0.0001
+checkpoint_period = 1
+kernel_init_param = 0.045
+epochs = 200

--- a/configs/NTU-V2/final/final_joint_no_rel_ave.cfg
+++ b/configs/NTU-V2/final/final_joint_no_rel_ave.cfg
@@ -5,7 +5,7 @@ add_body_part = False
 timesteps = 32
 skip_timesteps = None
 normalization = 'NTU'
-sample_method = 'all'
+sample_method = 'central'
 arch = 'joint'
 
 [model]

--- a/configs/NTU-V2/final/final_joint_rel_att.cfg
+++ b/configs/NTU-V2/final/final_joint_rel_att.cfg
@@ -1,0 +1,26 @@
+[data]
+selected_joints = ['Nose', 'Neck', 'MidHip', 'RWrist', 'LWrist', 'RAnkle', 'LAnkle']
+add_joint_idx = False
+add_body_part = False
+timesteps = 32
+skip_timesteps = None
+normalization = 'NTU'
+sample_method = 'all'
+arch = 'joint'
+
+[model]
+rel_type = 'joint_stream'
+fuse_type = None
+compute_distance = False
+compute_motion = False
+use_relations = True
+use_attention = True
+return_attention = False
+
+[train]
+drop_rate = 0.1
+kernel_init_type = 'TruncatedNormal'
+learning_rate = 0.0001
+checkpoint_period = 1
+kernel_init_param = 0.045
+epochs = 200

--- a/configs/NTU-V2/final/final_joint_rel_att.cfg
+++ b/configs/NTU-V2/final/final_joint_rel_att.cfg
@@ -5,7 +5,7 @@ add_body_part = False
 timesteps = 32
 skip_timesteps = None
 normalization = 'NTU'
-sample_method = 'all'
+sample_method = 'central'
 arch = 'joint'
 
 [model]

--- a/configs/NTU-V2/final/final_joint_rel_ave.cfg
+++ b/configs/NTU-V2/final/final_joint_rel_ave.cfg
@@ -1,0 +1,26 @@
+[data]
+selected_joints = ['Nose', 'Neck', 'MidHip', 'RWrist', 'LWrist', 'RAnkle', 'LAnkle']
+add_joint_idx = False
+add_body_part = False
+timesteps = 32
+skip_timesteps = None
+normalization = 'NTU'
+sample_method = 'all'
+arch = 'joint'
+
+[model]
+rel_type = 'joint_stream'
+fuse_type = None
+compute_distance = False
+compute_motion = False
+use_relations = True
+use_attention = False
+return_attention = False
+
+[train]
+drop_rate = 0.1
+kernel_init_type = 'TruncatedNormal'
+learning_rate = 0.0001
+checkpoint_period = 1
+kernel_init_param = 0.045
+epochs = 200

--- a/configs/NTU-V2/final/final_joint_rel_ave.cfg
+++ b/configs/NTU-V2/final/final_joint_rel_ave.cfg
@@ -5,7 +5,7 @@ add_body_part = False
 timesteps = 32
 skip_timesteps = None
 normalization = 'NTU'
-sample_method = 'all'
+sample_method = 'central'
 arch = 'joint'
 
 [model]

--- a/configs/NTU-V2/final/final_temp_no_rel_att.cfg
+++ b/configs/NTU-V2/final/final_temp_no_rel_att.cfg
@@ -5,7 +5,7 @@ add_body_part = False
 timesteps = 32
 skip_timesteps = None
 normalization = 'NTU'
-sample_method = 'all'
+sample_method = 'central'
 arch = 'temp'
 
 [model]

--- a/configs/NTU-V2/final/final_temp_no_rel_att.cfg
+++ b/configs/NTU-V2/final/final_temp_no_rel_att.cfg
@@ -1,0 +1,26 @@
+[data]
+selected_joints = ['Nose', 'Neck', 'MidHip', 'RWrist', 'LWrist', 'RAnkle', 'LAnkle']
+add_joint_idx = False
+add_body_part = False
+timesteps = 32
+skip_timesteps = None
+normalization = 'NTU'
+sample_method = 'all'
+arch = 'temp'
+
+[model]
+rel_type = 'temp_stream'
+fuse_type = None
+compute_distance = False
+compute_motion = False
+use_relations = False
+use_attention = True
+return_attention = False
+
+[train]
+drop_rate = 0.1
+kernel_init_type = 'TruncatedNormal'
+learning_rate = 0.0001
+checkpoint_period = 1
+kernel_init_param = 0.045
+epochs = 200

--- a/configs/NTU-V2/final/final_temp_no_rel_ave.cfg
+++ b/configs/NTU-V2/final/final_temp_no_rel_ave.cfg
@@ -1,0 +1,26 @@
+[data]
+selected_joints = ['Nose', 'Neck', 'MidHip', 'RWrist', 'LWrist', 'RAnkle', 'LAnkle']
+add_joint_idx = False
+add_body_part = False
+timesteps = 32
+skip_timesteps = None
+normalization = 'NTU'
+sample_method = 'all'
+arch = 'temp'
+
+[model]
+rel_type = 'temp_stream'
+fuse_type = None
+compute_distance = False
+compute_motion = False
+use_relations = False
+use_attention = False
+return_attention = False
+
+[train]
+drop_rate = 0.1
+kernel_init_type = 'TruncatedNormal'
+learning_rate = 0.0001
+checkpoint_period = 1
+kernel_init_param = 0.045
+epochs = 200

--- a/configs/NTU-V2/final/final_temp_no_rel_ave.cfg
+++ b/configs/NTU-V2/final/final_temp_no_rel_ave.cfg
@@ -5,7 +5,7 @@ add_body_part = False
 timesteps = 32
 skip_timesteps = None
 normalization = 'NTU'
-sample_method = 'all'
+sample_method = 'central'
 arch = 'temp'
 
 [model]

--- a/configs/NTU-V2/final/final_temp_rel_att.cfg
+++ b/configs/NTU-V2/final/final_temp_rel_att.cfg
@@ -1,0 +1,26 @@
+[data]
+selected_joints = ['Nose', 'Neck', 'MidHip', 'RWrist', 'LWrist', 'RAnkle', 'LAnkle']
+add_joint_idx = False
+add_body_part = False
+timesteps = 32
+skip_timesteps = None
+normalization = 'NTU'
+sample_method = 'all'
+arch = 'temp'
+
+[model]
+rel_type = 'temp_stream'
+fuse_type = None
+compute_distance = False
+compute_motion = False
+use_relations = True
+use_attention = True
+return_attention = False
+
+[train]
+drop_rate = 0.1
+kernel_init_type = 'TruncatedNormal'
+learning_rate = 0.0001
+checkpoint_period = 1
+kernel_init_param = 0.045
+epochs = 200

--- a/configs/NTU-V2/final/final_temp_rel_att.cfg
+++ b/configs/NTU-V2/final/final_temp_rel_att.cfg
@@ -5,7 +5,7 @@ add_body_part = False
 timesteps = 32
 skip_timesteps = None
 normalization = 'NTU'
-sample_method = 'all'
+sample_method = 'central'
 arch = 'temp'
 
 [model]

--- a/configs/NTU-V2/final/final_temp_rel_ave.cfg
+++ b/configs/NTU-V2/final/final_temp_rel_ave.cfg
@@ -5,7 +5,7 @@ add_body_part = False
 timesteps = 32
 skip_timesteps = None
 normalization = 'NTU'
-sample_method = 'all'
+sample_method = 'central'
 arch = 'temp'
 
 [model]

--- a/configs/NTU-V2/final/final_temp_rel_ave.cfg
+++ b/configs/NTU-V2/final/final_temp_rel_ave.cfg
@@ -1,0 +1,26 @@
+[data]
+selected_joints = ['Nose', 'Neck', 'MidHip', 'RWrist', 'LWrist', 'RAnkle', 'LAnkle']
+add_joint_idx = False
+add_body_part = False
+timesteps = 32
+skip_timesteps = None
+normalization = 'NTU'
+sample_method = 'all'
+arch = 'temp'
+
+[model]
+rel_type = 'temp_stream'
+fuse_type = None
+compute_distance = False
+compute_motion = False
+use_relations = True
+use_attention = False
+return_attention = False
+
+[train]
+drop_rate = 0.1
+kernel_init_type = 'TruncatedNormal'
+learning_rate = 0.0001
+checkpoint_period = 1
+kernel_init_param = 0.045
+epochs = 200

--- a/configs/NTU-V2/final/lstm/IRN_final_no_rel_att_after_lstm.cfg
+++ b/configs/NTU-V2/final/lstm/IRN_final_no_rel_att_after_lstm.cfg
@@ -1,0 +1,13 @@
+[fusion]
+config_filepaths = ['configs/NTU-V2/final/final_joint_no_rel_att_lstm.cfg', 'configs/NTU-V2/final/final_temp_no_rel_att_lstm.cfg']
+weights_filepaths = ['models/NTU-V2/final_joint_no_rel_att_lstm/fold_cross_x/rerun_x/relnet_weights.hdf5', 'models/NTU-V2/final_temp_no_rel_att_lstm/fold_cross_x/rerun_x/relnet_weights.hdf5']
+freeze_g_theta = False
+fuse_at_fc1 = False
+new_arch = True
+avg_at_end = True
+
+[train]
+drop_rate = 0.1
+epochs = 200
+learning_rate = 0.0001
+checkpoint_period = 1

--- a/configs/NTU-V2/final/lstm/IRN_final_no_rel_att_before_lstm.cfg
+++ b/configs/NTU-V2/final/lstm/IRN_final_no_rel_att_before_lstm.cfg
@@ -1,0 +1,13 @@
+[fusion]
+config_filepaths = ['configs/NTU-V2/final/final_joint_no_rel_att_lstm.cfg', 'configs/NTU-V2/final/final_temp_no_rel_att_lstm.cfg']
+weights_filepaths = ['models/NTU-V2/final_joint_no_rel_att_lstm/fold_cross_x/rerun_x/relnet_weights.hdf5', 'models/NTU-V2/final_temp_no_rel_att_lstm/fold_cross_x/rerun_x/relnet_weights.hdf5']
+freeze_g_theta = False
+fuse_at_fc1 = False
+new_arch = True
+avg_at_end = False
+
+[train]
+drop_rate = 0.1
+epochs = 200
+learning_rate = 0.0001
+checkpoint_period = 1

--- a/configs/NTU-V2/final/lstm/IRN_final_no_rel_ave_after_lstm.cfg
+++ b/configs/NTU-V2/final/lstm/IRN_final_no_rel_ave_after_lstm.cfg
@@ -1,0 +1,13 @@
+[fusion]
+config_filepaths = ['configs/NTU-V2/final/final_joint_no_rel_ave_lstm.cfg', 'configs/NTU-V2/final/final_temp_no_rel_ave_lstm.cfg']
+weights_filepaths = ['models/NTU-V2/final_joint_no_rel_ave_lstm/fold_cross_x/rerun_x/relnet_weights.hdf5', 'models/NTU-V2/final_temp_no_rel_ave_lstm/fold_cross_x/rerun_x/relnet_weights.hdf5']
+freeze_g_theta = False
+fuse_at_fc1 = False
+new_arch = True
+avg_at_end = True
+
+[train]
+drop_rate = 0.1
+epochs = 200
+learning_rate = 0.0001
+checkpoint_period = 1

--- a/configs/NTU-V2/final/lstm/IRN_final_no_rel_ave_before_lstm.cfg
+++ b/configs/NTU-V2/final/lstm/IRN_final_no_rel_ave_before_lstm.cfg
@@ -1,0 +1,13 @@
+[fusion]
+config_filepaths = ['configs/NTU-V2/final/final_joint_no_rel_ave_lstm.cfg', 'configs/NTU-V2/final/final_temp_no_rel_ave_lstm.cfg']
+weights_filepaths = ['models/NTU-V2/final_joint_no_rel_ave_lstm/fold_cross_x/rerun_x/relnet_weights.hdf5', 'models/NTU-V2/final_temp_no_rel_ave_lstm/fold_cross_x/rerun_x/relnet_weights.hdf5']
+freeze_g_theta = False
+fuse_at_fc1 = False
+new_arch = True
+avg_at_end = False
+
+[train]
+drop_rate = 0.1
+epochs = 200
+learning_rate = 0.0001
+checkpoint_period = 1

--- a/configs/NTU-V2/final/lstm/IRN_final_rel_att_after_lstm.cfg
+++ b/configs/NTU-V2/final/lstm/IRN_final_rel_att_after_lstm.cfg
@@ -1,0 +1,13 @@
+[fusion]
+config_filepaths = ['configs/NTU-V2/final/final_joint_rel_att_lstm.cfg', 'configs/NTU-V2/final/final_temp_rel_att_lstm.cfg']
+weights_filepaths = ['models/NTU-V2/final_joint_rel_att_lstm/fold_cross_x/rerun_x/relnet_weights.hdf5', 'models/NTU-V2/final_temp_rel_att_lstm/fold_cross_x/rerun_x/relnet_weights.hdf5']
+freeze_g_theta = False
+fuse_at_fc1 = False
+new_arch = True
+avg_at_end = True
+
+[train]
+drop_rate = 0.1
+epochs = 200
+learning_rate = 0.0001
+checkpoint_period = 1

--- a/configs/NTU-V2/final/lstm/IRN_final_rel_att_before_lstm.cfg
+++ b/configs/NTU-V2/final/lstm/IRN_final_rel_att_before_lstm.cfg
@@ -1,0 +1,13 @@
+[fusion]
+config_filepaths = ['configs/NTU-V2/final/final_joint_rel_att_lstm.cfg', 'configs/NTU-V2/final/final_temp_rel_att_lstm.cfg']
+weights_filepaths = ['models/NTU-V2/final_joint_rel_att_lstm/fold_cross_x/rerun_x/relnet_weights.hdf5', 'models/NTU-V2/final_temp_rel_att_lstm/fold_cross_x/rerun_x/relnet_weights.hdf5']
+freeze_g_theta = False
+fuse_at_fc1 = False
+new_arch = True
+avg_at_end = False
+
+[train]
+drop_rate = 0.1
+epochs = 200
+learning_rate = 0.0001
+checkpoint_period = 1

--- a/configs/NTU-V2/final/lstm/IRN_final_rel_ave_after_lstm.cfg
+++ b/configs/NTU-V2/final/lstm/IRN_final_rel_ave_after_lstm.cfg
@@ -1,0 +1,13 @@
+[fusion]
+config_filepaths = ['configs/NTU-V2/final/final_joint_rel_ave_lstm.cfg', 'configs/NTU-V2/final/final_temp_rel_ave_lstm.cfg']
+weights_filepaths = ['models/NTU-V2/final_joint_rel_ave_lstm/fold_cross_x/rerun_x/relnet_weights.hdf5', 'models/NTU-V2/final_temp_rel_ave_lstm/fold_cross_x/rerun_x/relnet_weights.hdf5']
+freeze_g_theta = False
+fuse_at_fc1 = False
+new_arch = True
+avg_at_end = True
+
+[train]
+drop_rate = 0.1
+epochs = 200
+learning_rate = 0.0001
+checkpoint_period = 1

--- a/configs/NTU-V2/final/lstm/IRN_final_rel_ave_before_lstm.cfg
+++ b/configs/NTU-V2/final/lstm/IRN_final_rel_ave_before_lstm.cfg
@@ -1,0 +1,13 @@
+[fusion]
+config_filepaths = ['configs/NTU-V2/final/final_joint_rel_ave_lstm.cfg', 'configs/NTU-V2/final/final_temp_rel_ave_lstm.cfg']
+weights_filepaths = ['models/NTU-V2/final_joint_rel_ave_lstm/fold_cross_x/rerun_x/relnet_weights.hdf5', 'models/NTU-V2/final_temp_rel_ave_lstm/fold_cross_x/rerun_x/relnet_weights.hdf5']
+freeze_g_theta = False
+fuse_at_fc1 = False
+new_arch = True
+avg_at_end = False
+
+[train]
+drop_rate = 0.1
+epochs = 200
+learning_rate = 0.0001
+checkpoint_period = 1

--- a/configs/NTU-V2/final/lstm/final_joint_no_rel_att_lstm.cfg
+++ b/configs/NTU-V2/final/lstm/final_joint_no_rel_att_lstm.cfg
@@ -1,0 +1,27 @@
+[data]
+selected_joints = ['Nose', 'Neck', 'MidHip', 'RWrist', 'LWrist', 'RAnkle', 'LAnkle']
+add_joint_idx = False
+add_body_part = False
+timesteps = 32
+skip_timesteps = None
+normalization = 'NTU'
+sample_method = 'all'
+seq_step = 16
+arch = 'joint-lstm'
+
+[model]
+rel_type = 'joint_stream'
+fuse_type = None
+compute_distance = False
+compute_motion = False
+use_relations = False
+use_attention = True
+return_attention = False
+
+[train]
+drop_rate = 0.1
+kernel_init_type = 'TruncatedNormal'
+learning_rate = 0.0001
+checkpoint_period = 1
+kernel_init_param = 0.045
+epochs = 200

--- a/configs/NTU-V2/final/lstm/final_joint_no_rel_ave_lstm.cfg
+++ b/configs/NTU-V2/final/lstm/final_joint_no_rel_ave_lstm.cfg
@@ -1,0 +1,27 @@
+[data]
+selected_joints = ['Nose', 'Neck', 'MidHip', 'RWrist', 'LWrist', 'RAnkle', 'LAnkle']
+add_joint_idx = False
+add_body_part = False
+timesteps = 32
+skip_timesteps = None
+normalization = 'NTU'
+sample_method = 'all'
+seq_step = 16
+arch = 'joint-lstm'
+
+[model]
+rel_type = 'joint_stream'
+fuse_type = None
+compute_distance = False
+compute_motion = False
+use_relations = False
+use_attention = False
+return_attention = False
+
+[train]
+drop_rate = 0.1
+kernel_init_type = 'TruncatedNormal'
+learning_rate = 0.0001
+checkpoint_period = 1
+kernel_init_param = 0.045
+epochs = 200

--- a/configs/NTU-V2/final/lstm/final_joint_rel_att_lstm.cfg
+++ b/configs/NTU-V2/final/lstm/final_joint_rel_att_lstm.cfg
@@ -1,0 +1,27 @@
+[data]
+selected_joints = ['Nose', 'Neck', 'MidHip', 'RWrist', 'LWrist', 'RAnkle', 'LAnkle']
+add_joint_idx = False
+add_body_part = False
+timesteps = 32
+skip_timesteps = None
+normalization = 'NTU'
+sample_method = 'all'
+seq_step = 16
+arch = 'joint-lstm'
+
+[model]
+rel_type = 'joint_stream'
+fuse_type = None
+compute_distance = False
+compute_motion = False
+use_relations = True
+use_attention = True
+return_attention = False
+
+[train]
+drop_rate = 0.1
+kernel_init_type = 'TruncatedNormal'
+learning_rate = 0.0001
+checkpoint_period = 1
+kernel_init_param = 0.045
+epochs = 200

--- a/configs/NTU-V2/final/lstm/final_joint_rel_ave_lstm.cfg
+++ b/configs/NTU-V2/final/lstm/final_joint_rel_ave_lstm.cfg
@@ -1,0 +1,27 @@
+[data]
+selected_joints = ['Nose', 'Neck', 'MidHip', 'RWrist', 'LWrist', 'RAnkle', 'LAnkle']
+add_joint_idx = False
+add_body_part = False
+timesteps = 32
+skip_timesteps = None
+normalization = 'NTU'
+sample_method = 'all'
+seq_step = 16
+arch = 'joint-lstm'
+
+[model]
+rel_type = 'joint_stream'
+fuse_type = None
+compute_distance = False
+compute_motion = False
+use_relations = True
+use_attention = False
+return_attention = False
+
+[train]
+drop_rate = 0.1
+kernel_init_type = 'TruncatedNormal'
+learning_rate = 0.0001
+checkpoint_period = 1
+kernel_init_param = 0.045
+epochs = 200

--- a/configs/NTU-V2/final/lstm/final_temp_no_rel_att_lstm.cfg
+++ b/configs/NTU-V2/final/lstm/final_temp_no_rel_att_lstm.cfg
@@ -1,0 +1,27 @@
+[data]
+selected_joints = ['Nose', 'Neck', 'MidHip', 'RWrist', 'LWrist', 'RAnkle', 'LAnkle']
+add_joint_idx = False
+add_body_part = False
+timesteps = 32
+skip_timesteps = None
+normalization = 'NTU'
+sample_method = 'all'
+seq_step = 16
+arch = 'temp-lstm'
+
+[model]
+rel_type = 'temp_stream'
+fuse_type = None
+compute_distance = False
+compute_motion = False
+use_relations = False
+use_attention = True
+return_attention = False
+
+[train]
+drop_rate = 0.1
+kernel_init_type = 'TruncatedNormal'
+learning_rate = 0.0001
+checkpoint_period = 1
+kernel_init_param = 0.045
+epochs = 200

--- a/configs/NTU-V2/final/lstm/final_temp_no_rel_ave_lstm.cfg
+++ b/configs/NTU-V2/final/lstm/final_temp_no_rel_ave_lstm.cfg
@@ -1,0 +1,27 @@
+[data]
+selected_joints = ['Nose', 'Neck', 'MidHip', 'RWrist', 'LWrist', 'RAnkle', 'LAnkle']
+add_joint_idx = False
+add_body_part = False
+timesteps = 32
+skip_timesteps = None
+normalization = 'NTU'
+sample_method = 'all'
+seq_step = 16
+arch = 'temp-lstm'
+
+[model]
+rel_type = 'temp_stream'
+fuse_type = None
+compute_distance = False
+compute_motion = False
+use_relations = False
+use_attention = False
+return_attention = False
+
+[train]
+drop_rate = 0.1
+kernel_init_type = 'TruncatedNormal'
+learning_rate = 0.0001
+checkpoint_period = 1
+kernel_init_param = 0.045
+epochs = 200

--- a/configs/NTU-V2/final/lstm/final_temp_rel_att_lstm.cfg
+++ b/configs/NTU-V2/final/lstm/final_temp_rel_att_lstm.cfg
@@ -1,0 +1,27 @@
+[data]
+selected_joints = ['Nose', 'Neck', 'MidHip', 'RWrist', 'LWrist', 'RAnkle', 'LAnkle']
+add_joint_idx = False
+add_body_part = False
+timesteps = 32
+skip_timesteps = None
+normalization = 'NTU'
+sample_method = 'all'
+seq_step = 16
+arch = 'temp-lstm'
+
+[model]
+rel_type = 'temp_stream'
+fuse_type = None
+compute_distance = False
+compute_motion = False
+use_relations = True
+use_attention = True
+return_attention = False
+
+[train]
+drop_rate = 0.1
+kernel_init_type = 'TruncatedNormal'
+learning_rate = 0.0001
+checkpoint_period = 1
+kernel_init_param = 0.045
+epochs = 200

--- a/configs/NTU-V2/final/lstm/final_temp_rel_ave_lstm.cfg
+++ b/configs/NTU-V2/final/lstm/final_temp_rel_ave_lstm.cfg
@@ -1,0 +1,27 @@
+[data]
+selected_joints = ['Nose', 'Neck', 'MidHip', 'RWrist', 'LWrist', 'RAnkle', 'LAnkle']
+add_joint_idx = False
+add_body_part = False
+timesteps = 32
+skip_timesteps = None
+normalization = 'NTU'
+sample_method = 'all'
+seq_step = 16
+arch = 'temp-lstm'
+
+[model]
+rel_type = 'temp_stream'
+fuse_type = None
+compute_distance = False
+compute_motion = False
+use_relations = True
+use_attention = False
+return_attention = False
+
+[train]
+drop_rate = 0.1
+kernel_init_type = 'TruncatedNormal'
+learning_rate = 0.0001
+checkpoint_period = 1
+kernel_init_param = 0.045
+epochs = 200

--- a/ntu_v2_runs.sh
+++ b/ntu_v2_runs.sh
@@ -1,0 +1,18 @@
+##NTU-v2 cs joint, temp, no lstm no two_stream
+# python3 src/run_protocol.py final_joint_rel_ave_cs configs/NTU-V2/final/final_joint_rel_ave.cfg NTU-V2 -n 5 -f cross_subject
+#python3 src/run_protocol.py final_joint_rel_ave_cv configs/NTU-V2/final/final_joint_rel_ave.cfg NTU-V2 -n 5 -f cross_view
+#python3 src/run_protocol.py final_joint_rel_att_cs configs/NTU-V2/final/final_joint_rel_att.cfg NTU-V2 -n 5 -f cross_subject
+#python3 src/run_protocol.py final_joint_rel_att_cv configs/NTU-V2/final/final_joint_rel_att.cfg NTU-V2 -n 5 -f cross_view
+#python3 src/run_protocol.py final_joint_no_rel_ave_cs configs/NTU-V2/final/final_joint_no_rel_ave.cfg NTU-V2 -n 5 -f cross_subject
+#python3 src/run_protocol.py final_joint_no_rel_ave_cv configs/NTU-V2/final/final_joint_no_rel_ave.cfg NTU-V2 -n 5 -f cross_view
+python3 src/run_protocol.py final_joint_no_rel_att_cs configs/NTU-V2/final/final_joint_no_rel_att.cfg NTU-V2 -n 5 -f cross_subject
+#python3 src/run_protocol.py final_joint_no_rel_att_cv configs/NTU-V2/final/final_joint_no_rel_att.cfg NTU-V2 -n 5 -f cross_view
+#
+#python3 src/run_protocol.py final_temp_rel_ave_cs configs/NTU-V2/final/final_temp_rel_ave.cfg NTU-V2 -n 5 -f cross_subject
+#python3 src/run_protocol.py final_temp_rel_ave_cv configs/NTU-V2/final/final_temp_rel_ave.cfg NTU-V2 -n 5 -f cross_view
+#python3 src/run_protocol.py final_temp_rel_att_cs configs/NTU-V2/final/final_temp_rel_att.cfg NTU-V2 -n 5 -f cross_subject
+#python3 src/run_protocol.py final_temp_rel_att_cv configs/NTU-V2/final/final_temp_rel_att.cfg NTU-V2 -n 5 -f cross_view
+#python3 src/run_protocol.py final_temp_no_rel_ave_cs configs/NTU-V2/final/final_temp_no_rel_ave.cfg NTU-V2 -n 5 -f cross_subject
+#python3 src/run_protocol.py final_temp_no_rel_ave_cv configs/NTU-V2/final/final_temp_no_rel_ave.cfg NTU-V2 -n 5 -f cross_view
+#python3 src/run_protocol.py final_temp_no_rel_att_cs configs/NTU-V2/final/final_temp_no_rel_att.cfg NTU-V2 -n 5 -f cross_subject
+#python3 src/run_protocol.py final_temp_no_rel_att_cv configs/NTU-V2/final/final_temp_no_rel_att.cfg NTU-V2 -n 5 -f cross_view

--- a/src/datasets/data_generator.py
+++ b/src/datasets/data_generator.py
@@ -58,7 +58,7 @@ class DataGenerator(Sequence):
                 subset, dataset_fold, data_kwargs['timesteps'],
                 data_kwargs['skip_timesteps'], data_kwargs['seq_step'])
             seqs_mapping_filepath = os.path.join(dataset.DATA_DIR, 'seqs_mapping', seqs_mapping_file)
-                
+            os.makedirs(os.path.join(dataset.DATA_DIR, 'seqs_mapping'), exist_ok=True)
             if os.path.exists(seqs_mapping_filepath):
                 type_index = type(self.ground_truth.index[0])
                 seqs_mapping = np.genfromtxt(seqs_mapping_filepath, dtype='str')

--- a/src/datasets/data_generator.py
+++ b/src/datasets/data_generator.py
@@ -57,7 +57,7 @@ class DataGenerator(Sequence):
             seqs_mapping_file = 'seqs_mapping-subset_{}-fold_{}-timesteps_{}-{}-seq_step_{}.csv'.format(
                 subset, dataset_fold, data_kwargs['timesteps'],
                 data_kwargs['skip_timesteps'], data_kwargs['seq_step'])
-            seqs_mapping_filepath = dataset.DATA_DIR + 'seqs_mapping/' + seqs_mapping_file
+            seqs_mapping_filepath = os.path.join(dataset.DATA_DIR, 'seqs_mapping', seqs_mapping_file)
                 
             if os.path.exists(seqs_mapping_filepath):
                 type_index = type(self.ground_truth.index[0])

--- a/src/train_rn.py
+++ b/src/train_rn.py
@@ -319,6 +319,9 @@ def train_rn(output_path, dataset_name, model_kwargs, data_kwargs,
     elif dataset_name == 'NTU':
         dataset = NTU
         use_data_gen = True # Unable to read all data at once, dataset too big.
+    elif dataset_name == 'NTU-V2':
+        dataset = NTU_V2
+        use_data_gen = True # Unable to read all data at once, dataset too big.
     
     if verbose > 0:
         print("Reading data...")


### PR DESCRIPTION
- added config files for NTU-v2
- minor path and dataset-specific fixes

To preserve the expt dir naming convention, I have not changed the dir names per experiment for the fusion models. I'm using root directory `models/NTU-V2/**(original experiment names)**` instead of `models/NTU/**(experiments with version appended)**`